### PR TITLE
Clean up docs+extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.1.1]
+
+### Fixed
+- Fixed `preprocess_tokens`, `get_tags`, and `get_embeddings` to not trigger package extension checks (leftover from carve out from PromptingTools)
+- Clean up docs references to `PromptingTools.Experimental.RAGTools`
+
 ## [0.1.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RAGTools"
 uuid = "16ddad29-bbe8-45a7-857d-3d9514eb0023"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -23,7 +23,7 @@ In addition, observe the "kwargs" names, that's how the keyword arguments for ea
 The system is designed to be hackable and extensible at almost every entry point.
 If you want to customize the behavior of any step, you can do so by defining a new type and defining a new method for the step you're changing, eg, 
 ```julia
-PromptingTools.Experimental.RAGTools: rerank
+using RAGTools: rerank
 
 struct MyReranker <: AbstractReranker end
 rerank(::MyReranker, index, candidates) = ...

--- a/src/annotation.jl
+++ b/src/annotation.jl
@@ -561,7 +561,7 @@ For any non-HTML styler, it prints the content as plain text.
 See also `HTMLStyler`, `annotate_support`, and `set_node_style!` for how the styling is applied and what the arguments mean.
 
 # Examples
-Note: `RT` is an alias for `PromptingTools.Experimental.RAGTools`
+Note: `RT` is an alias for `RAGTools`
 
 Simple start directly with the `RAGResult`:
 ```julia

--- a/src/preparation.jl
+++ b/src/preparation.jl
@@ -265,11 +265,6 @@ function get_embeddings(embedder::BatchEmbedder, docs::AbstractVector{<:Abstract
         kwargs...)
     @assert !isempty(docs) "The list of docs to get embeddings from should not be empty."
 
-    ## check if extension is available
-    ext = Base.get_extension(PromptingTools, :RAGToolsExperimentalExt)
-    if isnothing(ext)
-        error("You need to also import LinearAlgebra, Unicode, SparseArrays to use this function")
-    end
     verbose && @info "Embedding $(length(docs)) documents..."
     # Notice that we embed multiple docs at once, not one by one
     # OpenAI supports embedding multiple documents to reduce the number of API calls/network latency time
@@ -531,11 +526,6 @@ function get_tags(tagger::OpenTagger, docs::AbstractVector{<:AbstractString};
         cost_tracker = Threads.Atomic{Float64}(0.0),
         kwargs...)
     _check_aiextract_capability(model)
-    ## check if extension is available
-    ext = Base.get_extension(PromptingTools, :RAGToolsExperimentalExt)
-    if isnothing(ext)
-        error("You need to also import LinearAlgebra, Unicode, and SparseArrays to use this function")
-    end
     verbose && @info "Extracting metadata from $(length(docs)) documents..."
     tags_extracted = asyncmap(docs) do docs_chunk
         try

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -476,12 +476,6 @@ end
 
 function preprocess_tokens(texts::Vector{<:AbstractString}, stemmer = nothing;
         stopwords::Union{Nothing, Set{String}} = nothing, min_length::Int = 3)
-    if !isnothing(stemmer)
-        ext = Base.get_extension(PromptingTools, :SnowballPromptingToolsExt)
-        if isnothing(ext)
-            error("You need to also import Snowball.jl to use this function")
-        end
-    end
     map(text -> preprocess_tokens(text, stemmer; stopwords, min_length), texts)
 end
 


### PR DESCRIPTION
- Fixed `preprocess_tokens`, `get_tags`, and `get_embeddings` to not trigger package extension checks (leftover from carve out from PromptingTools)
- Clean up docs references to `PromptingTools.Experimental.RAGTools`