### PR TITLE
Add ProgressMeter for embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Progress bar for `get_embeddings` given it can take a while for large documents (new dependency `ProgressMeter.jl`, but extremely lightweight)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Progress bar for `get_embeddings` given it can take a while for large documents (new dependency `ProgressMeter.jl`, but extremely lightweight)
+- Progress bar for `get_embeddings` given it can take a while for large documents (new dependency `ProgressMeter.jl`, but extremely lightweight). Make sure to set kwargs to `embedder_kwargs=(;verbose=true)` to see it.
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "RAGTools"
 uuid = "16ddad29-bbe8-45a7-857d-3d9514eb0023"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 PromptingTools = "670122d1-24a8-4d70-bfce-740807c42192"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Snowball = "fb8f903a-0164-4e73-9ffe-431110250c3b"
@@ -27,6 +28,7 @@ FlashRank = "0.4.1"
 HTTP = "1.10.15"
 JSON3 = "1.14.1"
 LinearAlgebra = "1"
+ProgressMeter = "1.10.2"
 PromptingTools = "0.72"
 Random = "1"
 Snowball = "0.1"

--- a/src/RAGTools.jl
+++ b/src/RAGTools.jl
@@ -7,6 +7,7 @@ using JSON3: StructTypes
 using AbstractTrees
 using AbstractTrees: PreOrderDFS
 const PT = PromptingTools
+using ProgressMeter
 
 ## Re-export PromptingTools
 using PromptingTools: aigenerate, aiembed, aiclassify, aiextract, aiscan, aiimage, @ai_str,


### PR DESCRIPTION
- Progress bar for `get_embeddings` given it can take a while for large documents (new dependency `ProgressMeter.jl`, but extremely lightweight). Make sure to set kwargs to `embedder_kwargs=(;verbose=true)` to see it.