### PR TITLE
Add RRF for hybrid indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.3.0]
+
+### Added
+- Added `ReciprocalRankFusionReranker` and associated `rerank` method for hybrid retrieval (MultiIndex with embeddings and keywords indices referring to the same chunks).
+
 ## [0.2.1]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RAGTools"
 uuid = "16ddad29-bbe8-45a7-857d-3d9514eb0023"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -749,7 +749,10 @@ scores1 = [0.9, 0.8, 0.7, 0.6, 0.5]
 positions2 = [2, 4, 6, 8, 10]
 scores2 = [0.5, 0.6, 0.7, 0.8, 0.9]
 
-merged, scores = reciprocal_rank_fusion(positions1, scores1, positions2, scores2; k = 60)
+merged_pos, scores_dict = reciprocal_rank_fusion(positions1, scores1, positions2, scores2; k = 60)
+
+# Create a CandidateChunks from the merged positions and scores
+cc = CandidateChunks(:my_index, merged_pos, [scores_dict[pos] for pos in merged_pos])
 ```
 """
 function reciprocal_rank_fusion(


### PR DESCRIPTION
- Added `ReciprocalRankFusionReranker` and associated `rerank` method for hybrid retrieval (MultiIndex with embeddings and keywords indices referring to the same chunks).